### PR TITLE
Tie the movement to delta time

### DIFF
--- a/Content/BP_RTSCamera.uasset
+++ b/Content/BP_RTSCamera.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cde9f455612a223ed74daa161f8d9ba2a6f1ef19a98112cfc4cfe630f4d3a6aa
-size 25065
+oid sha256:984f7fd67597cf686d4ae09a89eea79bd93739d28fd6d6a2dfc726819974a50c
+size 25165

--- a/OpenRTSCamera.uplugin
+++ b/OpenRTSCamera.uplugin
@@ -18,7 +18,9 @@
 			"Name": "OpenRTSCamera",
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
-			"WhitelistPlatforms": ["Win64"]
+			"PlatformAllowList": [
+				"Win64"
+			]
 		}
 	],
 	"Plugins": [
@@ -29,5 +31,5 @@
 	],
 	"SupportURL": "https://github.com/HeyZoos/OpenRTSCamera/issues",
 	"Version": 1,
-	"VersionName": "0.16.0"
+	"VersionName": "0.17.0"
 }

--- a/Source/OpenRTSCamera/Public/RTSCamera.h
+++ b/Source/OpenRTSCamera/Public/RTSCamera.h
@@ -9,6 +9,22 @@
 #include "GameFramework/SpringArmComponent.h"
 #include "RTSCamera.generated.h"
 
+/**
+ * We use these commands so that move camera inputs can be tied to the tick rate of the game.
+ * https://github.com/HeyZoos/OpenRTSCamera/issues/27
+ */
+USTRUCT()
+struct FMoveCameraCommand
+{
+	GENERATED_BODY()
+	UPROPERTY()
+	float X;
+	UPROPERTY()
+	float Y;
+	UPROPERTY()
+	float Scale;
+};
+
 UCLASS(Blueprintable, ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
 class OPENRTSCAMERA_API URTSCamera : public UActorComponent
 {
@@ -125,7 +141,8 @@ protected:
 	void OnMoveCameraXAxis(const FInputActionValue& Value);
 	void OnDragCamera(const FInputActionValue& Value);
 
-	void MoveSpringArmWithMoveSpeed(float X, float Y, float Scale) const;
+	void RequestMoveCamera(float X, float Y, float Scale);
+	void ApplyMoveCameraCommands();
 
 	UPROPERTY()
 	AActor* Owner;
@@ -175,4 +192,6 @@ private:
 	bool IsDragging;
 	UPROPERTY()
 	FVector2D DragStartLocation;
+	UPROPERTY()
+	TArray<FMoveCameraCommand> MoveCameraCommands;
 };


### PR DESCRIPTION
Fixes #27 

Fixes the issue where the camera movement gets slower or faster depending on the game frame rate. It accomplishes this by taking the tick delta times into account for WASD, Edge, and drag movement.