### PR TITLE
Feature: Unified Movement Speed and Zoom-Based Velocity Scaling

### DIFF
--- a/Source/OpenRTSCamera/Public/RTSCamera.h
+++ b/Source/OpenRTSCamera/Public/RTSCamera.h
@@ -66,7 +66,9 @@ public:
 	float StartingZAngle;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "RTSCamera")
-	float MoveSpeed;
+	float MaxMoveSpeed;
+	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "RTSCamera")
+	float MinMoveSpeed;
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "RTSCamera")
 	float RotateSpeed;
 	
@@ -104,13 +106,7 @@ public:
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, Category = "RTSCamera - Edge Scroll Settings")
 	bool EnableEdgeScrolling;
-	UPROPERTY(
-		BlueprintReadWrite,
-		EditAnywhere,
-		Category = "RTSCamera - Edge Scroll Settings",
-		meta=(EditCondition="EnableEdgeScrolling")
-	)
-	float EdgeScrollSpeed;
+
 	UPROPERTY(
 		BlueprintReadWrite,
 		EditAnywhere,
@@ -199,4 +195,6 @@ private:
 	FVector2D DragStartLocation;
 	UPROPERTY()
 	TArray<FMoveCameraCommand> MoveCameraCommands;
+	UPROPERTY()
+	float NowMoveSpeed;
 };


### PR DESCRIPTION
### Feature: Unified Movement Speed and Zoom-Based Velocity Scaling

This PR optimizes the camera's kinetic feel by unifying movement calculations and introducing dynamic speed scaling based on zoom altitude.

#### 1. Unification of Movement Variables
- **Change**: Replaced independent \EdgeScrollSpeed\ and \MoveSpeed\ constants with a unified \NowMoveSpeed\ model.
- **Why**: Previously, WASD input and Edge Scrolling used separate speed values, leading to inconsistent behavior. By consolidating them, all camera displacement (Keyboard, Edge Scroll, Drag) now shares a unified, predictable velocity model.

#### 2. Zoom-Linked Velocity Scaling
- **Change**: Implemented linear interpolation (Lerp) for \NowMoveSpeed\ based on current zoom height.
- **Why**: Fixed-speed cameras feel sluggish at high altitudes and hyper-sensitive at low altitudes. This change ensures a consistent \screen traversal time\ for the player regardless of zoom level, improving overall control precision.

#### 3. Refactored Movement Application
- **Change**: Updated \ApplyMoveCameraCommands\ and \EdgeScroll\ logic to utilize the shared \NowMoveSpeed\.
- **Why**: Eliminates redundant hardcoded speed injections and ensures that any future changes to the movement curve automatically apply to all input methods.